### PR TITLE
feat: added a text shadow feature 

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "axe/aria": [
+      "default",
+      {
+        "aria-valid-attr-value": "off"
+      }
+    ],
+    "axe/forms": [
+      "default",
+      {
+        "label": "off"
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "just-type-shii",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slider": "^1.3.5",
         "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -977,6 +978,248 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.5.tgz",
+      "integrity": "sha512-rkfe2pU2NBAYfGaxa3Mqosi7VZEWX5CxKaanRv0vZd4Zhl9fvQrg0VM93dv3xGLGfrHuoTRF3JXH8nb9g+B3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1322,7 +1565,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1332,7 +1575,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2473,7 +2716,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-slider": "^1.3.5",
     "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/components/just-type-shii.tsx
+++ b/src/app/components/just-type-shii.tsx
@@ -14,6 +14,7 @@ import { useControlsVisibility } from "../hooks/use-controls-visibility"
 import { DownloadButton } from "./download-btn"
 import { useSearchParams, useRouter } from "next/navigation"
 import ToastMsg from "./toast-msg"
+import { TextShadowPicker } from "./text-shadow"
 export default function JustTypeShii() {
     const [isDark, setIsDark] = useState(true)
     const [textColor, setTextColor] = useState("#ffffff")
@@ -29,6 +30,15 @@ export default function JustTypeShii() {
     const [showBackgroundPicker, setShowBackgroundPicker] = useState(false)
     const [showFontSize, setShowFontSize] = useState(false)
     const [showFontPicker, setShowFontPicker] = useState(false)
+    // default values for shadow
+    const [textShadow, setTextShadow] = useState({
+        x: 4,
+        y: 2,
+        blur: 4,
+        color: "#000000",
+        opacity: 0.5
+    });
+   
 
     const inputRef = useRef<HTMLTextAreaElement>(null) as React.RefObject<HTMLTextAreaElement>
     const [toastMsg, setToastMsg] = useState<string | null>(null)
@@ -46,6 +56,17 @@ export default function JustTypeShii() {
     })
 
     useAutoFocus(inputRef)
+
+    // Convert the Hex to Rgba or converting into numbers ex:- 203,40,80
+    const hexToRgba = (hex: string, alpha: number) => {
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
+        return `rgba(${r},${g},${b},${alpha})`;
+    };
+
+    const textShadowCss = `${textShadow.x}px ${textShadow.y}px ${textShadow.blur}px ${hexToRgba(textShadow.color, textShadow.opacity)}`;
+
 
     // Load initial state from URL or localStorage
     useEffect(() => {
@@ -239,10 +260,18 @@ export default function JustTypeShii() {
                         onOpen={() => { }}
                         isDark={isDark}
                     />
+                    
+                    {/* Text Shadow Section */}
+                    <TextShadowPicker 
+                        value={textShadow}
+                        onChange={setTextShadow}
+                        isDark={isDark}
+                    />
+
                 </div>
 
 
-                <TextArea ref={inputRef} text={text} setText={setText} textColor={textColor} fontSize={fontSize} selectedFont={selectedFont} />
+                <TextArea ref={inputRef} text={text} setText={setText} textColor={textColor} textShadow={textShadowCss} fontSize={fontSize} selectedFont={selectedFont} />
 
                 <Title showControls={showControls} isDark={isDark} />
                 <AmbientBackground backgroundColor={backgroundColor} isDark={isDark} />

--- a/src/app/components/text-area.tsx
+++ b/src/app/components/text-area.tsx
@@ -2,16 +2,19 @@
 
 import { forwardRef } from "react"
 
+
 interface TextAreaProps {
   text: string
   setText: (text: string) => void
   textColor: string
   fontSize: number
   selectedFont: string
+  textShadow?: string
 }
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ text, setText, textColor, fontSize, selectedFont }, ref) => {
+  ({ text, setText, textColor, fontSize, selectedFont, textShadow }, ref) => {
+
     return (
       <textarea
         ref={ref}
@@ -19,9 +22,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         onChange={(e) => setText(e.target.value)}
         placeholder=""
         autoFocus
-  aria-label="Editor"
-        spellCheck={false}         
-        autoCorrect="off"         
+        aria-label="Editor"
+        spellCheck={false}
+        autoCorrect="off"
         autoCapitalize="off"
         className={`fixed inset-0 w-full h-full p-20 bg-transparent border-none outline-none resize-none ${selectedFont} tracking-wide leading-relaxed text-center`}
         style={{
@@ -31,9 +34,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           paddingTop: "calc(50vh - 0.5em)",
           paddingBottom: "calc(50vh - 0.5em)",
           overflow: "hidden",
+          textShadow: textShadow || "none"
         }}
       />
-
     )
   },
 )

--- a/src/app/components/text-shadow.tsx
+++ b/src/app/components/text-shadow.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Slider } from "@/components/ui/slider";
+import { Blend } from "lucide-react";
+import { useState } from "react";
+
+interface TextShadowSettings {
+  x: number;
+  y: number;
+  blur: number;
+  color: string;
+  opacity: number;
+}
+
+interface TextShadowPickerProps {
+  value: TextShadowSettings;
+  onChange: (newShadow: TextShadowSettings) => void;
+  isDark?: boolean;
+}
+
+export function TextShadowPicker({ value, onChange, isDark = false }: TextShadowPickerProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleChange = (field: keyof TextShadowSettings, val: number | string) => {
+    const newShadow = { ...value, [field]: val };
+    onChange(newShadow);
+  };
+
+  const handleStepperChange = (field: keyof TextShadowSettings, increment: number) => {
+    const currentValue = value[field] as number;
+    let newValue = currentValue + increment;
+    
+    // set's bounds for different fields
+    if (field === 'opacity') {
+      newValue = Math.max(0, Math.min(1, newValue));
+    } else if (field === 'blur') {
+      newValue = Math.max(0, newValue);
+    }
+    
+    handleChange(field, newValue);
+  };
+
+  const hexToRgba = (hex: string, alpha: number) => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `rgba(${r},${g},${b},${alpha})`;
+  };
+
+  const shadowCss = `${value.x}px ${value.y}px ${value.blur}px ${hexToRgba(value.color, value.opacity)}`;
+
+  return (
+    <div className="w-full">
+      <button
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className={`
+          flex items-center justify-between gap-3 px-4 py-3 w-full border cursor-pointer
+          transition-all duration-200 backdrop-blur-sm
+          ${open ? "rounded-t-2xl rounded-b-none" : "rounded-2xl"}
+          ${isDark
+            ? "bg-black border-neutral-800 text-white hover:bg-neutral-900"
+            : "bg-white border-neutral-300 text-black hover:bg-neutral-100 shadow-lg"
+          }
+        `}
+      >
+        <div className=" flex justify-center items-center gap-x-2 font-medium">
+          <Blend className="w-5 h-5 "/>
+          Text Shadow</div>
+        <svg
+          className={`h-4 w-4 transition-transform duration-200 ${open ? "rotate-90" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+
+      <div
+        className={`
+          overflow-hidden transition-all duration-300 ease-out
+          ${open ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}
+          ${isDark ? "bg-black border-x border-b border-neutral-800 text-white" : "bg-white border-x border-b border-neutral-300 text-black"}
+          backdrop-blur-sm shadow-xl rounded-b-2xl p-4 space-y-4
+        `}
+      >
+ 
+ 
+        <div className="space-y-2">
+          <label className="text-sm font-medium block">Horizontal ({value.x}px)</label>
+          <Slider
+            value={[value.x]}
+            onValueChange={(val) => handleChange("x", val[0])}
+            min={-20}
+            max={20}
+            step={1}
+          />
+        </div>
+
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium block">Vertical ({value.y}px)</label>
+          <Slider
+            value={[value.y]}
+            onValueChange={(val) => handleChange("y", val[0])}
+            min={-20}
+            max={20}
+            step={1}
+          />
+        </div>
+
+  
+        <div className="space-y-2">
+          <label className="text-sm font-medium block">Blur ({value.blur}px)</label>
+          <Slider
+            value={[value.blur]}
+            onValueChange={(val) => handleChange("blur", val[0])}
+            min={0}
+            max={20}
+            step={1}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium block">Shadow Color</label>
+          <div className="flex items-center gap-3">
+            <input
+              type="color"
+              value={value.color}
+              onChange={(e) => handleChange("color", e.target.value)}
+              className="w-12 h-8 rounded-md border-0 cursor-pointer"
+            />
+            <span className="text-sm font-mono">{value.color}</span>
+          </div>
+        </div>
+
+        
+        <div className="space-y-2">
+          <label className="text-sm font-medium block">
+            Opacity ({Math.round(value.opacity * 100)}%)
+          </label>
+          <Slider
+            value={[value.opacity]}
+            onValueChange={(val) => handleChange("opacity", val[0])}
+            min={0}
+            max={1}
+            step={0.01}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import { cn } from "@/lib/utils";
+
+function Slider({
+  className,
+  min = 0,
+  max = 100,
+  step = 1,
+  value,
+  defaultValue,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  return (
+    <SliderPrimitive.Root
+      value={value}
+      defaultValue={defaultValue}
+      min={min}
+      max={max}
+      step={step}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="bg-muted relative grow overflow-hidden rounded-full h-1.5">
+        <SliderPrimitive.Range className="bg-primary absolute h-full" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };


### PR DESCRIPTION
Summary :- This PR adds a new Text Shadow customization panel to the editor, allowing users to adjust horizontal/vertical offset, blur, color, and opacity for text elements

new component:-  /src/app/components/text-shadow
Updated Files:- 
1)  /src/app/just-type-shii  — Added logic to apply text shadow settings to rendered text.
2) /src/app/text-area.tsx    — Integrated TextShadowPicker and passed shadow values to the text area preview.

What are added in text-shadow
1# horizontal offset (X)
2# vertical offset (Y)
3# blur radius
4# opacity (0–100%)
5# color picker for shadow color selection.

preview: 
<img width="1919" height="866" alt="text-shadow1" src="https://github.com/user-attachments/assets/501a42a5-fcce-46f4-b5e5-f7af1940ebdd" />
<img width="1919" height="871" alt="text-shadow2" src="https://github.com/user-attachments/assets/50657a62-ad87-4251-b1d9-68e27ead2290" />

